### PR TITLE
neues Feld: sparBeginn

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ dies über fachliche Meldungen mitteilen. Hierfür sieht die Antwort das Feld Me
         },
         "vermittlerNr": "A123456",
         "vertragsDatum": "2015-09-01",
+        "sparBeginn": "2016-01-01",
         "vertriebsGruppe": "Vertrieb A",
         "zielTarif": "T1",
         "zuteilungstermin": "2026-01-01",
@@ -158,6 +159,7 @@ dies über fachliche Meldungen mitteilen. Hierfür sieht die Antwort das Feld Me
 | bausparkasseIstDarlehensgeber                           | Boolean       | Ist true, wenn Darlehensgeber und Bausparkasse identisch sind, sonst false
 | zuteilungstermin                                        | Datum         | Das gewünschte Zuteilungsdatum. Alternativ kann ``laufzeitBisZuteilungInMonaten`` geliefert werden. |
 | vertragsDatum                                           | Datum         | Das gewünschte VertragsDatum. |
+| sparBeginn                                              | Datum         | Der gewünschte Sparbeginn. |
 | sparBeitraege                                           | Liste         | Ermöglicht die Erfassung mehrerer unterschiedlicher Sparzahlungen oder Einmalzahlungen. |
 | sparBeitraege[i].beitrag                                | Dezimalzahl   | Der Sparbeitrag dieser Zahlung ein Euro. |
 | sparBeitraege[i].zahlungAb                              | Datum         | Der Startzeitpunkt ab dem dieser Sparbeitrag geleistet wird. |
@@ -266,6 +268,7 @@ dies über fachliche Meldungen mitteilen. Hierfür sieht die Antwort das Feld Me
           },
           "tarif": "string",
           "vertragsDatum": "2015-09-01",
+          "sparBeginn": "2016-01-01",
           "zuteilungsTermin": "string",
           "provision" : {
             "vertriebsProvisionInEuro": 1000
@@ -281,6 +284,7 @@ dies über fachliche Meldungen mitteilen. Hierfür sieht die Antwort das Feld Me
 | laufzeitBisZuteilungInMonaten                                         | Ganzzahl     | Anzahl Monate bis zur Zuteilung                                                                                                                                   |
 | zuteilungsTermin                                                      | Datum        | Zuteilungstermin                                                                                                                                                  |
 | vertragsDatum                                                         | Datum        |                                                                                                                                                                   |
+| sparBeginn                                                            | Datum        |                                                                                                                                                                   |
 | abschlussgebuehrenbehandlung                                          | Aufzählung   | Mögliche Werte sind: ``VERRECHNUNG``, ``SOFORTZAHLUNG``.                                                                                                           |
 | abschlussgebuehrHoeheInProzent                                        | Dezimalzahl  | Abschlussgebühr in Prozent                                                                                                                                        |
 | abschlussgebuehrBetragInEuro                                          | Dezimalzahl  | Abschlussgebühr in Euro                                                                                                                                           |
@@ -436,7 +440,8 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
        "fallNummer":"123-456-789",
        "requestId":"87e6rt5",
        "fallAuswahl": false,
-       "vertragsDatum":"2015-09-30"
+       "vertragsDatum":"2015-09-30",
+       "sparBeginn":"2016-01-01",
        "riesterDaten": 
        {
             "riesterzulagenVerwendung": "SOFORTZAHLUNG",
@@ -531,6 +536,7 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
 | requestId                                                             | String                 | Ordnet die Anfrage einer EUROPACE Anfrage für Loggingzwecke zu.                                                                                                              |
 | fallNummer                                                            | String                 | Ordnet die Anfrage einer EUROPACE Fallakte für Loggingzwecke zu.                                                                                                             |
 | vertragsDatum                                                         | Datum                  |                                                                                                                                                                              |
+| sparBeginn                                                            | Datum                  |                                                                                                                                                                              |
 | riesterDaten.riesterzulagenVerwendung                                 | String                 | Legt die Verwendung der Riesterzulagen fest (SONDERZAHLUNG, VERRECHNUNG). |
 | riesterDaten.geburtsdatumAntragsteller                                | Datum                  | Geburtsdatum des Antragstellers |
 | riesterDaten.beschaeftigungAntragsteller                              | Aufzählung             | Mögliche Werte: ``ANGESTELLTER``, ``ARBEITER``, ``ARBEITSLOSER``, ``BEAMTER``, ``FREIBERUFLER``, ``HAUSFRAU_HAUSMANN``, ``RENTNER``, ``SELBSTAENDIGER``. | 

--- a/src/main/java/de/hypoport/efi/bausparen/model/berechnung/anfrage/BausparBerechnungsAnfrage.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/berechnung/anfrage/BausparBerechnungsAnfrage.java
@@ -19,6 +19,7 @@ public class BausparBerechnungsAnfrage {
   Boolean bausparkasseIstDarlehensgeber;
   LocalDate zuteilungstermin;
   LocalDate vertragsDatum;
+  LocalDate sparBeginn;
   List<SparBeitrag> sparBeitraege;
   TilgungsBeitrag tilgungsBeitrag;
   Abschlussgebuehrenbehandlung abschlussgebuehrenbehandlung;
@@ -131,6 +132,14 @@ public class BausparBerechnungsAnfrage {
 
   public void setVertragsDatum(LocalDate vertragsDatum) {
     this.vertragsDatum = vertragsDatum;
+  }
+
+  public LocalDate getSparBeginn() {
+    return sparBeginn;
+  }
+
+  public void setSparBeginn(LocalDate sparBeginn) {
+    this.sparBeginn = sparBeginn;
   }
 
   public BerechnungsArt getBerechnungsArt() {

--- a/src/main/java/de/hypoport/efi/bausparen/model/berechnung/angebot/Bausparangebot.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/berechnung/angebot/Bausparangebot.java
@@ -22,6 +22,7 @@ public class Bausparangebot {
   Integer gesamtlaufzeitKomplettInMonaten;
   List<FachlicheMeldung> meldungen;
   LocalDate vertragsDatum;
+  LocalDate sparBeginn;
   Provision provision;
 
   public String getTarif() {
@@ -126,6 +127,14 @@ public class Bausparangebot {
 
   public void setVertragsDatum(LocalDate vertragsDatum) {
     this.vertragsDatum = vertragsDatum;
+  }
+
+  public LocalDate getSparBeginn() {
+    return sparBeginn;
+  }
+
+  public void setSparBeginn(LocalDate sparBeginn) {
+    this.sparBeginn = sparBeginn;
   }
 
   public Provision getProvision() {

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
@@ -20,6 +20,7 @@ public class DokumentErzeugenAnfrage {
   VermittlerDaten vermittlerDaten;
   SparphaseDokument sparphaseDokument;
   LocalDate vertragsDatum;
+  LocalDate sparBeginn;
   String fallNummer;
   String requestId;
   Boolean fallAuswahl;
@@ -95,6 +96,14 @@ public class DokumentErzeugenAnfrage {
 
   public void setVertragsDatum(LocalDate vertragsDatum) {
     this.vertragsDatum = vertragsDatum;
+  }
+
+  public LocalDate getSparBeginn() {
+    return sparBeginn;
+  }
+
+  public void setSparBeginn(LocalDate sparBeginn) {
+    this.sparBeginn = sparBeginn;
   }
 
   public String getFallNummer() {

--- a/src/main/resources/berechnetesbausparangebot.json
+++ b/src/main/resources/berechnetesbausparangebot.json
@@ -2,6 +2,7 @@
   "berechnetesBausparAngebot": {
     "tarif": "T1",
     "vertragsDatum":"2015-09-01",
+    "sparBeginn": "2016-01-01",
     "berechnungsziel": "SPARBEITRAG",
     "abschlussgebuehr": {
       "abschlussgebuehrBetragInEuro": 500,

--- a/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
+++ b/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
@@ -83,6 +83,7 @@ public class FachlicheBeispieleTest {
     assertNotNull(bausparBerechnungsAnfrage.getZielTarif());
     assertNotNull(bausparBerechnungsAnfrage.getBerechnungsZiel());
     assertNotNull(bausparBerechnungsAnfrage.getVertragsDatum());
+    assertNotNull(bausparBerechnungsAnfrage.getSparBeginn());
     assertNotNull(bausparBerechnungsAnfrage.getBerechnungsArt());
     assertNotNull(bausparBerechnungsAnfrage.getAbschlussgebuehrenbehandlung());
     assertNotNull(bausparBerechnungsAnfrage.getFallNummer());
@@ -120,6 +121,7 @@ public class FachlicheBeispieleTest {
     assertVermittlerDaten(dokumentErzeugenAnfrage.getVermittlerDaten());
     assertSparphaseDokument(dokumentErzeugenAnfrage.getSparphaseDokument());
     assertNotNull(dokumentErzeugenAnfrage.getVertragsDatum());
+    assertNotNull(dokumentErzeugenAnfrage.getSparBeginn());
     assertNotNull(dokumentErzeugenAnfrage.getFallNummer());
     assertNotNull(dokumentErzeugenAnfrage.getRequestId());
     assertNotNull(dokumentErzeugenAnfrage.getFallAuswahl());

--- a/src/test/resources/testfall1/berechnetesbausparangebot.json
+++ b/src/test/resources/testfall1/berechnetesbausparangebot.json
@@ -2,6 +2,7 @@
   "berechnetesBausparAngebot": {
     "tarif": "T1",
     "vertragsDatum":"2015-09-01",
+    "sparBeginn": "2016-01-01",
     "berechnungsziel": "SPARBEITRAG",
     "abschlussgebuehr": {
       "abschlussgebuehrBetragInEuro": 500,

--- a/src/test/resources/testfall1/berechnungsanfrage.json
+++ b/src/test/resources/testfall1/berechnungsanfrage.json
@@ -5,6 +5,7 @@
   "abschlussgebuehrenbehandlung": "SOFORTZAHLUNG",
   "darlehensWunsch": "MIT_DARLEHEN",
   "vertragsDatum": "2015-09-01",
+  "sparBeginn": "2016-01-01",
   "laufzeitBisZuteilungInMonaten": 120,
   "bausparkasseIstDarlehensgeber": true,
   "fallNummer": "123-456-789",

--- a/src/test/resources/testfall1/dokumenteanfrage.json
+++ b/src/test/resources/testfall1/dokumenteanfrage.json
@@ -83,6 +83,7 @@
     "vermittlerNr": null
   },
   "vertragsDatum": "2015-09-01",
+  "sparBeginn": "2016-01-01",
   "fallNummer": "123-456-789",
   "requestId": "7y65xc4v",
   "fallAuswahl": false,

--- a/src/test/resources/testfall2/berechnetesbausparangebot.json
+++ b/src/test/resources/testfall2/berechnetesbausparangebot.json
@@ -2,6 +2,7 @@
   "berechnetesBausparAngebot": {
     "tarif": "T2",
     "vertragsDatum":"2015-09-01",
+    "sparBeginn": "2016-01-01",
     "berechnungsziel": "SPARBEITRAG",
     "abschlussgebuehr": {
       "abschlussgebuehrBetragInEuro": 1500,

--- a/src/test/resources/testfall2/berechnungsanfrage.json
+++ b/src/test/resources/testfall2/berechnungsanfrage.json
@@ -2,6 +2,7 @@
   "abschlussgebuehrenbehandlung": "SOFORTZAHLUNG",
   "berechnungsZiel": "SPARBEITRAG",
   "vertragsDatum": "2015-09-01",
+  "sparBeginn": "2016-01-01",
   "berechnungsArt": "TILGUNGSAUSSETZUNG",
   "darlehensWunsch": "MIT_DARLEHEN",
   "laufzeitBisZuteilungInMonaten": 240,

--- a/src/test/resources/testfall2/dokumenteanfrage.json
+++ b/src/test/resources/testfall2/dokumenteanfrage.json
@@ -142,6 +142,7 @@
     "vermittlerNr": null
   },
   "vertragsDatum": "2015-09-01",
+  "sparBeginn": "2016-01-01",
   "fallNummer": "123-456-789",
   "requestId": "87e6rt5",
   "fallAuswahl": true,


### PR DESCRIPTION
Zukünftig ist es im Frontend (BaufiSmart) möglich, einen gewünschten Sparbeginn für den Bausparvertrag anzugeben. Dieser Sparbeginn wird an die Bausparkassen geschickt und von diesen für die Berechnung des Bausparvertrages verwendet. In der Antwort wird dann der tatsächlich verwendete Sparbeginn zurückgeschickt und an das Frontend weitergeleitet. Dieser wird dann in den Finanzierungsdetails angezeigt.

https://trello.com/c/0DpRLmQK/300-sparbeginn-bausparen-in-services-umsetzen