### PR TITLE
Erweiterung dokumentenanfrage

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,17 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
        "fallAuswahl": false,
        "vertragsDatum":"2015-09-30",
        "sparBeginn":"2016-01-01",
+       "berechnungsZiel": "SPARBEITRAG",
+       "darlehensWunsch": "MIT_DARLEHEN",
+       "vertriebsGruppe": "Vertrieb A",
+       "laufzeitBisZuteilungInMonaten": 120,
+       "zielTarif": "T1",
+       "zuteilungstermin": "2025-09-01",
+       "tilgungsBeitrag":
+       {
+           "rateInEuro": 100,
+           "zahlungsrhythmus": "MONATLICH"
+       },
        "riesterDaten": 
        {
             "riesterzulagenVerwendung": "SOFORTZAHLUNG",
@@ -539,6 +550,14 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
 | fallNummer                                                            | String                 | Ordnet die Anfrage einer EUROPACE Fallakte für Loggingzwecke zu.                                                                                                             |
 | vertragsDatum                                                         | Datum                  |                                                                                                                                                                              |
 | sparBeginn                                                            | Datum                  |                                                                                                                                                                              |
+| berechnungsZiel                                                       | Aufzählung             | Mögliche Werte: ``SPARBEITRAG``, ``BAUSPARSUMME``, ``ZUTEILUNGSTERMIN``, ``LAUFZEIT_BIS_ZUTEILUNG`` |
+| darlehensWunsch                                                       | Aufzählung             | Soll ein Bauspar- oder Zuteilungsdarlehen in Anspruch genommen werden? Mögliche Werte sind: ``MIT_DARLEHEN``, ``OHNE_DARLEHEN``. |
+| vertriebsGruppe                                                       | String                 | Vertriebsgruppe des anfragenden Vertriebs zur Bestimmung der Provision. |
+| laufzeitBisZuteilungInMonaten                                         | Ganzzahl               | Die Anzahl Monate zwischen Vertragsdatum und Zuteilungsdatum. Entweder wird dieses Feld oder ``zuteilungstermin`` geliefert.|
+| zielTarif                                                             | String                 | Die technische Tarif ID, so wie sie von GET /tarife geliefert wird. |
+| zuteilungstermin                                                      | Datum                  | Das gewünschte Zuteilungsdatum. Alternativ kann ``laufzeitBisZuteilungInMonaten`` geliefert werden. |
+| tilgungsBeitrag.rateInEuro                                            | Dezimalzahl            | Höhe der Tilgungsrate(Zins und Tilgung des Darlehens)|
+| tilgungsBeitrag.zahlungsrhythmus                                      | Aufzählung             | Legt fest, in welchen Intervallen die Tilgungsrate gezahlt wird. Mögliche Werte sind: ``MONATLICH``, ``VIERTELJAEHRLICH``, ``HALBJAEHRLICH``, ``JAEHRLICH``, ``EINMALIG``. |
 | riesterDaten.riesterzulagenVerwendung                                 | String                 | Legt die Verwendung der Riesterzulagen fest (SONDERZAHLUNG, VERRECHNUNG). |
 | riesterDaten.geburtsdatumAntragsteller                                | Datum                  | Geburtsdatum des Antragstellers |
 | riesterDaten.beschaeftigungAntragsteller                              | Aufzählung             | Mögliche Werte: ``ANGESTELLTER``, ``ARBEITER``, ``ARBEITSLOSER``, ``BEAMTER``, ``FREIBERUFLER``, ``HAUSFRAU_HAUSMANN``, ``RENTNER``, ``SELBSTAENDIGER``. | 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Aug 26 15:20:51 CEST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip

--- a/src/main/java/de/hypoport/efi/bausparen/model/basis/DarlehensWunsch.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/basis/DarlehensWunsch.java
@@ -1,4 +1,4 @@
-package de.hypoport.efi.bausparen.model.berechnung.anfrage;
+package de.hypoport.efi.bausparen.model.basis;
 
 public enum DarlehensWunsch {
 

--- a/src/main/java/de/hypoport/efi/bausparen/model/basis/TilgungsBeitrag.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/basis/TilgungsBeitrag.java
@@ -1,4 +1,4 @@
-package de.hypoport.efi.bausparen.model.berechnung.anfrage;
+package de.hypoport.efi.bausparen.model.basis;
 
 import de.hypoport.efi.bausparen.model.basis.Zahlungsrhythmus;
 

--- a/src/main/java/de/hypoport/efi/bausparen/model/basis/TilgungsBeitrag.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/basis/TilgungsBeitrag.java
@@ -1,7 +1,5 @@
 package de.hypoport.efi.bausparen.model.basis;
 
-import de.hypoport.efi.bausparen.model.basis.Zahlungsrhythmus;
-
 import java.math.BigDecimal;
 
 public class TilgungsBeitrag {

--- a/src/main/java/de/hypoport/efi/bausparen/model/berechnung/anfrage/BausparBerechnungsAnfrage.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/berechnung/anfrage/BausparBerechnungsAnfrage.java
@@ -2,8 +2,10 @@ package de.hypoport.efi.bausparen.model.berechnung.anfrage;
 
 import de.hypoport.efi.bausparen.model.basis.Abschlussgebuehrenbehandlung;
 import de.hypoport.efi.bausparen.model.basis.BerechnungsZiel;
+import de.hypoport.efi.bausparen.model.basis.DarlehensWunsch;
 import de.hypoport.efi.bausparen.model.basis.RiesterDaten;
 import de.hypoport.efi.bausparen.model.basis.SparBeitrag;
+import de.hypoport.efi.bausparen.model.basis.TilgungsBeitrag;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
@@ -1,7 +1,10 @@
 package de.hypoport.efi.bausparen.model.dokumente;
 
 import de.hypoport.efi.bausparen.model.basis.Abschlussgebuehrenbehandlung;
+import de.hypoport.efi.bausparen.model.basis.BerechnungsZiel;
 import de.hypoport.efi.bausparen.model.basis.RiesterDaten;
+import de.hypoport.efi.bausparen.model.basis.DarlehensWunsch;
+import de.hypoport.efi.bausparen.model.basis.TilgungsBeitrag;
 import de.hypoport.efi.bausparen.model.berechnung.anfrage.BerechnungsArt;
 
 import java.math.BigDecimal;
@@ -25,6 +28,13 @@ public class DokumentErzeugenAnfrage {
   String requestId;
   Boolean fallAuswahl;
   RiesterDaten riesterDaten;
+  BerechnungsZiel berechnungsZiel;
+  DarlehensWunsch darlehensWunsch;
+  Integer laufzeitBisZuteilungInMonaten;
+  String vertriebsGruppe;
+  String zielTarif;
+  LocalDate zuteilungstermin;
+  TilgungsBeitrag tilgungsBeitrag;
 
   public String getTarif() {
     return tarif;
@@ -145,4 +155,61 @@ public class DokumentErzeugenAnfrage {
   public void setRiesterDaten(RiesterDaten riesterDaten) {
     this.riesterDaten = riesterDaten;
   }
+
+  public BerechnungsZiel getBerechnungsZiel() {
+    return berechnungsZiel;
+  }
+
+  public void setBerechnungsZiel(BerechnungsZiel berechnungsZiel) {
+    this.berechnungsZiel = berechnungsZiel;
+  }
+
+  public DarlehensWunsch getDarlehensWunsch() {
+    return darlehensWunsch;
+  }
+
+  public void setDarlehensWunsch(DarlehensWunsch darlehensWunsch) {
+    this.darlehensWunsch = darlehensWunsch;
+  }
+
+  public Integer getLaufzeitBisZuteilungInMonaten() {
+    return laufzeitBisZuteilungInMonaten;
+  }
+
+  public void setLaufzeitBisZuteilungInMonaten(Integer laufzeitBisZuteilungInMonaten) {
+    this.laufzeitBisZuteilungInMonaten = laufzeitBisZuteilungInMonaten;
+  }
+
+  public String getVertriebsGruppe() {
+    return vertriebsGruppe;
+  }
+
+  public void setVertriebsGruppe(String vertriebsGruppe) {
+    this.vertriebsGruppe = vertriebsGruppe;
+  }
+
+  public String getZielTarif() {
+    return zielTarif;
+  }
+
+  public void setZielTarif(String zielTarif) {
+    this.zielTarif = zielTarif;
+  }
+
+  public LocalDate getZuteilungstermin() {
+    return zuteilungstermin;
+  }
+
+  public void setZuteilungstermin(LocalDate zuteilungstermin) {
+    this.zuteilungstermin = zuteilungstermin;
+  }
+
+  public TilgungsBeitrag getTilgungsBeitrag() {
+    return tilgungsBeitrag;
+  }
+
+  public void setTilgungsBeitrag(TilgungsBeitrag tilgungsBeitrag) {
+    this.tilgungsBeitrag = tilgungsBeitrag;
+  }
+
 }

--- a/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
+++ b/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
@@ -2,6 +2,7 @@ package de.hypoport.efi.bausparen.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.hypoport.efi.bausparen.model.basis.SparBeitrag;
+import de.hypoport.efi.bausparen.model.basis.TilgungsBeitrag;
 import de.hypoport.efi.bausparen.model.berechnung.anfrage.BausparBerechnungsAnfrage;
 import de.hypoport.efi.bausparen.model.berechnung.angebot.BausparBerechnungsAntwort;
 import de.hypoport.efi.bausparen.model.berechnung.angebot.Bausparangebot;
@@ -122,6 +123,13 @@ public class FachlicheBeispieleTest {
     assertSparphaseDokument(dokumentErzeugenAnfrage.getSparphaseDokument());
     assertNotNull(dokumentErzeugenAnfrage.getVertragsDatum());
     assertNotNull(dokumentErzeugenAnfrage.getSparBeginn());
+    assertNotNull(dokumentErzeugenAnfrage.getLaufzeitBisZuteilungInMonaten());
+    assertNotNull(dokumentErzeugenAnfrage.getVertriebsGruppe());
+    assertNotNull(dokumentErzeugenAnfrage.getZielTarif());
+    assertNotNull(dokumentErzeugenAnfrage.getZuteilungstermin());
+    assertNotNull(dokumentErzeugenAnfrage.getBerechnungsZiel());
+    assertNotNull(dokumentErzeugenAnfrage.getDarlehensWunsch());
+    assertTilgungsBeitrag(dokumentErzeugenAnfrage.getTilgungsBeitrag());
     assertNotNull(dokumentErzeugenAnfrage.getFallNummer());
     assertNotNull(dokumentErzeugenAnfrage.getRequestId());
     assertNotNull(dokumentErzeugenAnfrage.getFallAuswahl());
@@ -133,6 +141,12 @@ public class FachlicheBeispieleTest {
     assertNotNull(antragstellerListe);
     assertTrue(antragstellerListe.size() > 0);
     assertAntragsteller(antragstellerListe.iterator().next());
+  }
+
+  private void assertTilgungsBeitrag(TilgungsBeitrag tilgungsBeitrag) {
+    assertNotNull(tilgungsBeitrag);
+    assertNotNull(tilgungsBeitrag.getZahlungsrhythmus());
+    assertNotNull(tilgungsBeitrag.getRateInEuro());
   }
 
   private void assertAntragsteller(Antragsteller antragsteller) {

--- a/src/test/resources/testfall1/dokumenteanfrage.json
+++ b/src/test/resources/testfall1/dokumenteanfrage.json
@@ -84,6 +84,16 @@
   },
   "vertragsDatum": "2015-09-01",
   "sparBeginn": "2016-01-01",
+  "berechnungsZiel": "SPARBEITRAG",
+  "darlehensWunsch": "MIT_DARLEHEN",
+  "vertriebsGruppe": "Vertrieb A",
+  "laufzeitBisZuteilungInMonaten": 120,
+  "zielTarif": "T1",
+  "zuteilungstermin": "2025-09-01",
+  "tilgungsBeitrag": {
+    "rateInEuro": 100,
+    "zahlungsrhythmus": "MONATLICH"
+  },
   "fallNummer": "123-456-789",
   "requestId": "7y65xc4v",
   "fallAuswahl": false,

--- a/src/test/resources/testfall2/dokumenteanfrage.json
+++ b/src/test/resources/testfall2/dokumenteanfrage.json
@@ -143,6 +143,16 @@
   },
   "vertragsDatum": "2015-09-01",
   "sparBeginn": "2016-01-01",
+  "berechnungsZiel": "SPARBEITRAG",
+  "darlehensWunsch": "MIT_DARLEHEN",
+  "vertriebsGruppe": "Vertrieb A",
+  "laufzeitBisZuteilungInMonaten": 120,
+  "zielTarif": "T1",
+  "zuteilungstermin": "2025-09-01",
+  "tilgungsBeitrag": {
+    "rateInEuro": 100,
+    "zahlungsrhythmus": "MONATLICH"
+  },
   "fallNummer": "123-456-789",
   "requestId": "87e6rt5",
   "fallAuswahl": true,


### PR DESCRIPTION
Die Dokumentenanfrage wurde um folgende Felder erweiterte:

- berechnungsZiel
- darlehensWunsch
- laufzeitBisZuteilungInMonaten
- vertriebsGruppe
- zielTarif
- zuteilungstermin
- tilgungsBeitrag.rateInEuro
- tilgungsBeitrag.zahlungsrhythmus

Json, Tests und README wurden entsprechend angepasst.

https://europace.atlassian.net/browse/PPK-1759