### PR TITLE
DokumentEzeugenAnfrage erweitert

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
            "zahlungsDaten":
            {
                "iban": null,
+               "bic": null,
                "nameKreditInstitut": null,
                "zahlungsForm": "LASTSCHRIFT"
            },
@@ -426,7 +427,8 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
             "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH",
             "bruttoEinkommenVorjahr": null,
             "bruttoEinkommenAktuellesJahr": null,
-            "guetertrennungVereinbart": null
+            "guetertrennungVereinbart": null,
+            "beruf": null,
        }],
        "vermittlerDaten": 
        {
@@ -516,6 +518,7 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
 | antragsteller[i].kontakt.eMailAdresse                                 | String                 |                                                                                                                                                                              |
 | antragsteller[i].familienStand                                        | Aufzählung             | Mögliche Werte sind: ``LEDIG``, ``VERHEIRATET``,  ``LEBENSPARTNER``, ``GESCHIEDEN``, ``VERWITWET``, ``GETRENNT_LEBEND``.                                                     |
 | antragsteller[i].zahlungsDaten.iban                                   | String                 |                                                                                                                                                                              |
+| antragsteller[i].zahlungsDaten.bic                                    | String                 |                                                                                                                                                                              |
 | antragsteller[i].zahlungsDaten.nameKreditInstitut                     | String                 |                                                                                                                                                                              |
 | antragsteller[i].zahlungsDaten.zahlungsForm                           | Aufzählung             | Mögliche Werte sind: ``LASTSCHRIFT``, ``UEBERWEISUNG``. Aktuell wird nur ``LASTSCHRIFT`` verwendet.                                                                                                                      |
 | antragsteller[i].beschaeftigungsVerhaeltnis                           | Aufzählung             | Mögliche Werte sind: ``ANGESTELLTER``, ``ARBEITER``, ``ARBEITSLOSER``, ``BEAMTER``, ``FREIBERUFLER``, ``HAUSFRAU_HAUSMANN``,``RENTNER``,``SELBSTAENDIGER``.                  |
@@ -538,6 +541,7 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
 | antragsteller[i].bruttoEinkommenVorjahr                               | Dezimalzahl            | Vorjahreseinkommen des Antragstellers.|
 | antragsteller[i].bruttoEinkommenAktuellesJahr                         | Dezimalzahl            | Aktuelles Jahreseinkommen des Antragstellers.|
 | antragsteller[i].guetertrennungVereinbart                             | Boolean                | Ist true, wenn Gütertrennung vereinbart wurde, sonst false. |
+| antragsteller[i].beruf                                                | String                 |                                                                                                                                                                              |
 | vermittlerDaten.nachName                                              | String                 |                                                                                                                                                                              |
 | vermittlerDaten.ort                                                   | String                 |                                                                                                                                                                              |
 | vermittlerDaten.postleitzahl                                          | String                 |                                                                                                                                                                              |

--- a/README.md
+++ b/README.md
@@ -479,7 +479,21 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
                 {
                    "geburtsdatum": "2018-01-01"
                 },
-        }       
+        }
+       "sonderZahlungen": [
+           {
+                "betrag": 200,
+                "zahlungsrhythmus": "MONATLICH",
+                "anzahl": 1,
+                "termin": "2015-05-01" 
+           },
+           {
+               "betrag": 300,
+               "zahlungsrhythmus": "MONATLICH",
+               "anzahl": 1,
+               "termin": "2016-05-01" 
+          }
+       ]
     }
 
 
@@ -579,7 +593,11 @@ Die automatische Feldausfüllung funktioniert nach dem best-effort Prinzip: Für
 | riesterDaten.einkommenAktuellesJahrEhepartner                         | Ganzzahl               | Höhe des Einkommens des aktuellen Jahres des Ehepartners. |
 | riesterDaten.zulagenKinderEhepartner                                  | Liste                  | Ermöglicht die Erfassung mehrerer förderfähiger Kinder des Ehepartners. |
 | riesterDaten.zulagenKind[i].geburtsdatum                              | Datum                  | Geburtsdatum des förderfähigen Kindes des Ehepartners. |
-
+| sonderZahlungen                                                       | Liste                  |                                                                                                                                                                              |
+| sonderZahlungen[i].betrag                                             | Dezimalzahl            | Betrag der Sonderzahlung in Euro                                                                                                                                             |
+| sonderZahlungen[i].zahlungsrhythmus                                   | Aufzählung             | Legt fest, in welchen Intervallen dieser Sparbeitrag gezahlt wird. Mögliche Werte sind: ``MONATLICH``, ``VIERTELJAEHRLICH``, ``HALBJAEHRLICH``, ``JAEHRLICH``, ``EINMALIG``. |
+| sonderZahlungen[i].termin                                             | Datum                  |                                                                                                                                                                              |
+| sonderZahlungen[i].anzahl                                             | Zahl                   |                                                                                                                                                                              |
 
 #### Antwort
     {

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/Antragsteller.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/Antragsteller.java
@@ -28,6 +28,7 @@ public class Antragsteller {
   BigDecimal bruttoEinkommenVorjahr;
   BigDecimal bruttoEinkommenAktuellesJahr;
   Boolean guetertrennungVereinbart;
+  String beruf;
 
   public String getNachName() {
     return nachName;
@@ -195,5 +196,13 @@ public class Antragsteller {
 
   public void setGuetertrennungVereinbart(Boolean guetertrennungVereinbart) {
     this.guetertrennungVereinbart = guetertrennungVereinbart;
+  }
+
+  public String getBeruf() {
+    return beruf;
+  }
+
+  public void setBeruf(String beruf) {
+    this.beruf = beruf;
   }
 }

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/DokumentErzeugenAnfrage.java
@@ -35,6 +35,7 @@ public class DokumentErzeugenAnfrage {
   String zielTarif;
   LocalDate zuteilungstermin;
   TilgungsBeitrag tilgungsBeitrag;
+  List<SonderZahlung> sonderZahlungen;
 
   public String getTarif() {
     return tarif;
@@ -212,4 +213,11 @@ public class DokumentErzeugenAnfrage {
     this.tilgungsBeitrag = tilgungsBeitrag;
   }
 
+  public List<SonderZahlung> getSonderZahlungen() {
+    return sonderZahlungen;
+  }
+
+  public void setSonderZahlungen(List<SonderZahlung> sonderZahlungen) {
+    this.sonderZahlungen = sonderZahlungen;
+  }
 }

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/SonderZahlung.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/SonderZahlung.java
@@ -1,0 +1,46 @@
+package de.hypoport.efi.bausparen.model.dokumente;
+
+import de.hypoport.efi.bausparen.model.basis.Zahlungsrhythmus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class SonderZahlung {
+
+    BigDecimal betrag;
+    Zahlungsrhythmus zahlungsrhythmus;
+    LocalDate termin;
+    Integer anzahl;
+
+    public BigDecimal getBetrag() {
+        return betrag;
+    }
+
+    public void setBetrag(BigDecimal betrag) {
+        this.betrag = betrag;
+    }
+
+    public Zahlungsrhythmus getZahlungsrhythmus() {
+        return zahlungsrhythmus;
+    }
+
+    public void setZahlungsrhythmus(Zahlungsrhythmus zahlungsrhythmus) {
+        this.zahlungsrhythmus = zahlungsrhythmus;
+    }
+
+    public LocalDate getTermin() {
+        return termin;
+    }
+
+    public void setTermin(LocalDate termin) {
+        this.termin = termin;
+    }
+
+    public Integer getAnzahl() {
+        return anzahl;
+    }
+
+    public void setAnzahl(Integer anzahl) {
+        this.anzahl = anzahl;
+    }
+}

--- a/src/main/java/de/hypoport/efi/bausparen/model/dokumente/ZahlungsDaten.java
+++ b/src/main/java/de/hypoport/efi/bausparen/model/dokumente/ZahlungsDaten.java
@@ -3,7 +3,7 @@ package de.hypoport.efi.bausparen.model.dokumente;
 public class ZahlungsDaten {
 
   String iban;
-
+  String bic;
   String nameKreditInstitut;
   ZahlungsForm zahlungsForm;
 
@@ -13,6 +13,14 @@ public class ZahlungsDaten {
 
   public void setIban(String iban) {
     this.iban = iban;
+  }
+
+  public String getBic() {
+    return bic;
+  }
+
+  public void setBic(String bic) {
+    this.bic = bic;
   }
 
   public String getNameKreditInstitut() {

--- a/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
+++ b/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
@@ -158,6 +158,7 @@ public class FachlicheBeispieleTest {
     assertNotNull(antragsteller.getKontakt().getTelefonNummer());
     assertNotNull(antragsteller.getFamilienStand());
     assertNotNull(antragsteller.getZahlungsDaten());
+    assertNotNull(antragsteller.getZahlungsDaten().getBic());
     assertNotNull(antragsteller.getZahlungsDaten().getZahlungsForm());
     assertNotNull(antragsteller.getBeschaeftigungsVerhaeltnis());
     assertNotNull(antragsteller.getLegitimation());
@@ -166,6 +167,7 @@ public class FachlicheBeispieleTest {
     assertNotNull(antragsteller.getTodesfallBeguenstigter().getAnrede());
     assertNotNull(antragsteller.getVermoegenswirksameLeistungenBetragInEuro());
     assertNotNull(antragsteller.getVermoegenswirksameLeistungenZahlungsrhythmus());
+    assertNotNull(antragsteller.getBeruf());
   }
 
   private void assertVermittlerDaten(VermittlerDaten vermittlerDaten) {

--- a/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
+++ b/src/test/java/de/hypoport/efi/bausparen/controller/FachlicheBeispieleTest.java
@@ -12,6 +12,7 @@ import de.hypoport.efi.bausparen.model.berechnung.angebot.TilgungsPlan;
 import de.hypoport.efi.bausparen.model.berechnung.angebot.TilgungsPlanZahlung;
 import de.hypoport.efi.bausparen.model.dokumente.Antragsteller;
 import de.hypoport.efi.bausparen.model.dokumente.DokumentErzeugenAnfrage;
+import de.hypoport.efi.bausparen.model.dokumente.SonderZahlung;
 import de.hypoport.efi.bausparen.model.dokumente.SparphaseDokument;
 import de.hypoport.efi.bausparen.model.dokumente.VermittlerDaten;
 import org.junit.Before;
@@ -135,6 +136,7 @@ public class FachlicheBeispieleTest {
     assertNotNull(dokumentErzeugenAnfrage.getFallAuswahl());
     assertNotNull(dokumentErzeugenAnfrage.getBausparkasseIstDarlehensgeber());
     assertNotNull(dokumentErzeugenAnfrage.getRiesterDaten());
+    assertSonderZahlungen(dokumentErzeugenAnfrage.getSonderZahlungen());
   }
 
   private void assertAntragsteller(List<Antragsteller> antragstellerListe) {
@@ -251,5 +253,18 @@ public class FachlicheBeispieleTest {
 
   private long monateZwischen(LocalDate erstesDatum, LocalDate zweitesDatumInklusive) {
     return Period.between(erstesDatum, zweitesDatumInklusive.plusDays(1)).toTotalMonths();
+  }
+
+  private void assertSonderZahlungen(List<SonderZahlung> sonderZahlungen){
+    assertNotNull(sonderZahlungen);
+    assertTrue(sonderZahlungen.size() > 0);
+    assertSonderZahlung(sonderZahlungen.iterator().next());
+  }
+
+  private void assertSonderZahlung(SonderZahlung sonderZahlung){
+    assertNotNull(sonderZahlung.getAnzahl());
+    assertNotNull(sonderZahlung.getBetrag());
+    assertNotNull(sonderZahlung.getTermin());
+    assertNotNull(sonderZahlung.getZahlungsrhythmus());
   }
 }

--- a/src/test/resources/testfall1/dokumenteanfrage.json
+++ b/src/test/resources/testfall1/dokumenteanfrage.json
@@ -106,5 +106,19 @@
         "geburtsdatum": "2018-01-01"
       }
     ]
-  }
+  },
+  "sonderZahlungen": [
+    {
+      "betrag": 200,
+      "zahlungsrhythmus": "MONATLICH",
+      "termin": "2015-09-01",
+      "anzahl": 1
+    },
+    {
+      "betrag": 200,
+      "zahlungsrhythmus": "MONATLICH",
+      "termin": "2015-11-01",
+      "anzahl": 1
+    }
+  ]
 }

--- a/src/test/resources/testfall1/dokumenteanfrage.json
+++ b/src/test/resources/testfall1/dokumenteanfrage.json
@@ -45,6 +45,7 @@
       "familienStand": "LEDIG",
       "zahlungsDaten": {
         "iban": null,
+        "bic": "CHEKDE81XXX",
         "nameKreditInstitut": null,
         "zahlungsForm": "LASTSCHRIFT"
       },
@@ -68,7 +69,8 @@
         }
       },
       "vermoegenswirksameLeistungenBetragInEuro": 30,
-      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH"
+      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH",
+      "beruf": "Fleischer"
     }
   ],
   "vermittlerDaten": {

--- a/src/test/resources/testfall2/dokumenteanfrage.json
+++ b/src/test/resources/testfall2/dokumenteanfrage.json
@@ -167,5 +167,19 @@
         "geburtsdatum": "2018-01-01"
       }
     ]
-  }
+  },
+  "sonderZahlungen": [
+    {
+      "betrag": 200,
+      "zahlungsrhythmus": "MONATLICH",
+      "termin": "2015-09-01",
+      "anzahl": 1
+    },
+    {
+      "betrag": 200,
+      "zahlungsrhythmus": "MONATLICH",
+      "termin": "2015-11-01",
+      "anzahl": 1
+    }
+  ]
 }

--- a/src/test/resources/testfall2/dokumenteanfrage.json
+++ b/src/test/resources/testfall2/dokumenteanfrage.json
@@ -52,6 +52,7 @@
       "familienStand": "LEBENSPARTNER",
       "zahlungsDaten": {
         "iban": null,
+        "bic": "CHEKDE81XXX",
         "nameKreditInstitut": null,
         "zahlungsForm": "LASTSCHRIFT"
       },
@@ -75,7 +76,8 @@
         }
       },
       "vermoegenswirksameLeistungenBetragInEuro": 30,
-      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH"
+      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH",
+      "beruf": "Fachinformatiker"
     },
     {
       "anrede": "FRAU",
@@ -104,6 +106,7 @@
       "familienStand": "LEBENSPARTNER",
       "zahlungsDaten": {
         "iban": null,
+        "bic": "CHEKDE81XXX",
         "nameKreditInstitut": null,
         "zahlungsForm": "LASTSCHRIFT"
       },
@@ -127,7 +130,8 @@
         }
       },
       "vermoegenswirksameLeistungenBetragInEuro": 30,
-      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH"
+      "vermoegenswirksameLeistungenZahlungsrhythmus": "MONATLICH",
+      "beruf": "Fleischer"
     }
   ],
   "vermittlerDaten": {


### PR DESCRIPTION
JIRA: https://finmas.atlassian.net/browse/ITDEV-522

Für die Befüllung des LBS-Bayern Bausparformulars wurde die DokumentErzeugenAnfrage um
"antragsteller.beruf", "antragsteller.zahlungsDaten.bic" und "sonderZahlungen" erweitert.

wbsk-service Pull Request: https://github.com/hypoport/wbsk-service/pull/367